### PR TITLE
Fix frontControllerPath for /wp-admin

### DIFF
--- a/RootsBedrockValetDriver.php
+++ b/RootsBedrockValetDriver.php
@@ -49,7 +49,10 @@ class RootsBedrockValetDriver extends BasicValetDriver
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
         if (0 === strpos($uri, '/wp/')) {
-            return $sitePath.$uri;
+            if (false === strpos($uri, '.php')) {
+                return $sitePath.'/web'.$uri.'/index.php';
+            }
+            return $sitePath.'/web'.$uri;
         }
 
         return $sitePath.'/web/index.php';


### PR DESCRIPTION
I'm using **Valet** version **1.1.12** and request to `/wp-admin` were failing with some errors.

<img width="1253" alt="screenshot 2016-05-28 01 16 09" src="https://cloud.githubusercontent.com/assets/6857732/15625137/7ab27b10-2472-11e6-9570-399ed50858f0.png">

This patch fixes it by making sure we are always in the `/web` dir and, also, that we point to a `index.php` file if needed.
